### PR TITLE
Apb 37 enable https

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -3,7 +3,6 @@ const express = require('express');
 const initServer = require('./initServer');
 const cors = require('cors');
 const path = require('path');
-const fs = require('fs');
 const readline = require('readline');
 
 // Initialize Firebase Admin

--- a/server/app.js
+++ b/server/app.js
@@ -1,9 +1,9 @@
 require('dotenv').config();
 const express = require('express');
-const http = require('http');
+const initServer = require('./initServer');
 const cors = require('cors');
 const path = require('path');
-const mongoose = require('mongoose');
+const fs = require('fs');
 const readline = require('readline');
 
 // Initialize Firebase Admin
@@ -15,7 +15,7 @@ admin.initializeApp({
 });
 
 const app = express();
-const server = http.createServer(app);
+const server = initServer(app);
 
 // Import all other sockets that are going to be used (they will automatically listen)
 const roomServiceSocket = require('./routes/sockets/room-service');
@@ -34,13 +34,8 @@ const roomService = new roomServiceSocket.RoomService(server, '/sockets/room-ser
 app.use(express.static(path.join(__dirname, '../ui/build')));
 
 // The home page
-app.get(/^\/(?!api).*/, function(req, res) {
+app.get(/^\/(?!api).*/, function (req, res) {
     res.sendFile(path.join(__dirname, '../ui/build', 'index.html'));
-});
-
-// Listen on the specified port for traffic
-app.listen(process.env.WEBSITE_PORT, function() {
-    console.log('Server is running on Port: ' + process.env.WEBSITE_PORT);
 });
 
 const rl = readline.createInterface({

--- a/server/example.env
+++ b/server/example.env
@@ -1,3 +1,9 @@
+# If in production
+# NODE_ENV="production"
+# CERT_KEY_PATH="path/to/private_key.pem"
+# CERT_PATH="path/to/cert.pem"
+# CERT_AUTHORITY_PATH="path/to/cert_authority.pem"
+
 WEBSITE_PORT=80
 SOCKET_PORT=8000
 FIREBASE_DB_URL="https://<project>.firebaseio.com"

--- a/server/initServer.js
+++ b/server/initServer.js
@@ -1,0 +1,29 @@
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+
+module.exports = (expressApp) => {
+    // Run HTTPS server if in production
+    if (process.env.NODE_ENV === 'production') {
+        const credentials = {
+            key: fs.readFileSync(process.env.CERT_KEY_PATH, 'utf8'),
+            cert: fs.readFileSync(process.env.CERT_PATH, 'utf8'),
+            ca: fs.readFileSync(process.env.CERT_AUTHORITY_PATH, 'utf8')
+        };
+
+        const server = https.createServer(credentials, expressApp);
+        const port = process.env.WEBSITE_PORT || 443;
+        server.listen(port, () => {
+            console.log(`HTTPS Server running on port ${port}`);
+        });
+        return server;
+    }
+
+    // HTTP otherwise
+    const server = http.createServer(expressApp);
+    const port = process.env.WEBSITE_PORT || 80;
+    server.listen(port, () => {
+        console.log(`HTTP Server running on port ${port}`);
+    });
+    return server;
+}


### PR DESCRIPTION
Added HTTPS support to the server, only when running in production mode: when the environment variable `NODE_ENV="production"`.

This requires a few extra environment variables to point to the keys and certificates, which are shown in the `example.env`.