### PR TITLE
Close the room whenever the host leaves the room.

### DIFF
--- a/server/routes/sockets/room-service.js
+++ b/server/routes/sockets/room-service.js
@@ -91,7 +91,11 @@ class RoomService {
                 && this.activeRoomsByID[connectedRoomID]
             ) {
                 const room = this.activeRoomsByID[connectedRoomID];
-                room.disconnectUserFromRoom(socket);
+                if (socket.id === room.hostSocketID) {
+                    this.closeRoom(room);
+                } else {
+                    room.disconnectUserFromRoom(socket);
+                }
             }
             // Remove the socket info from the activeSocketsByID list
             delete this.activeSocketsByID[socket.id];
@@ -103,8 +107,8 @@ class RoomService {
     /**
      * Create the room and set it in the list of active rooms by ID
      */
-    createRoom(roomID, roomConfig, hostUID) {
-        this.activeRoomsByID[roomID] = new roomAPI.Room(this.io, roomID, roomConfig, hostUID);
+    createRoom(roomID, roomConfig, hostUID, hostSocketID) {
+        this.activeRoomsByID[roomID] = new roomAPI.Room(this.io, roomID, roomConfig, hostUID, hostSocketID);
     }
 
     /**
@@ -172,7 +176,7 @@ class RoomService {
                 // Get the UID from the token to set as the room's host.
                 const hostUID = await this.getUID(eventInfo.authToken);
                 // Create the new room and store the info in the list of rooms
-                this.createRoom(eventInfo.roomID, eventInfo.roomConfig, hostUID);
+                this.createRoom(eventInfo.roomID, eventInfo.roomConfig, hostUID, socket.id);
                 // Emit a create_success event to the host
                 this.emitUserEvent('create_success', socket);
             }

--- a/server/routes/sockets/room.js
+++ b/server/routes/sockets/room.js
@@ -28,6 +28,7 @@ class Room {
         // We need to store a room state that can be passed to users
         // (especially those joining late).
         this.roomState = {
+            hostSocketID,
             phase: Constants.VOTING_PHASE,
             voteByUserID: {},
             connectedUsersByID: {},

--- a/server/routes/sockets/room.js
+++ b/server/routes/sockets/room.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const Constants = require('../../constants');
 
 class Room {
-    constructor(ioRef, roomID, roomConfig, hostUID) {
+    constructor(ioRef, roomID, roomConfig, hostUID, hostSocketID) {
         // This is the reference to the io server
         this.ioRef = ioRef;
         // The reference to the appropriate io room ("channel")
@@ -13,6 +13,8 @@ class Room {
         this.deck = this.roomConfig.deck;
         // The host's user ID for authentication
         this.hostUID = hostUID;
+        // The host's socket ID for handling closing room connections
+        this.hostSocketID = hostSocketID;
 
         // If the allowAbstain property is set, we need to add an
         // abstain option to the room's deck
@@ -93,10 +95,15 @@ class Room {
      */
     disconnectAllUsers() {
         for (const userID in this.roomState.connectedUsersByID) {
-            // Disconnect the user from the room channel.
-            this.ioRef.sockets.sockets[userID].leave(this.roomID);
-            // Emit a host_closed_connection event to the user.
-            this.emitUserEvent('host_closed_connection', this.roomState.connectedUsersByID[userID]);
+            try {
+                // Disconnect the user from the room channel.
+                this.ioRef.sockets.sockets[userID].leave(this.roomID);
+                // Emit a host_closed_room event to the user.
+                this.emitUserEvent('host_closed_room', this.roomState.connectedUsersByID[userID]);
+            } catch (err) {
+                // This will get triggered if the host leaves the room since their socket likely no longer exists
+                console.error(err);
+            }
         }
     }
 

--- a/ui/src/pages/DemoPage.js
+++ b/ui/src/pages/DemoPage.js
@@ -59,6 +59,7 @@ class DemoPage extends Component {
         this.props.roomServiceSocket.on('host_room_closed_success', event => this.onHostRoomClosedSuccess(event));
         this.props.roomServiceSocket.on('not_authorized', event => this.onNotAuthorized(event));
         this.props.roomServiceSocket.on('room_status_fetched', event => this.onRoomStatusFetched(event));
+        this.props.roomServiceSocket.on('host_closed_room', event => this.onHostClosedRoom(event));
     }
 
     onNotAuthorized(event) {
@@ -114,6 +115,13 @@ class DemoPage extends Component {
         });
     }
 
+    onHostClosedRoom(event) {
+        console.log('The host has closed the room. You have been disconnected.');
+        this.setState({
+            roomState: null,
+        });
+    }
+
     onHostRoomClosedSuccess(event) {
         console.log('You have successfully closed the room.');
     }
@@ -160,6 +168,8 @@ class DemoPage extends Component {
     }
 
     render() {
+        console.log(this.props.roomServiceSocket ? this.props.roomServiceSocket.id : 'No Socket');
+        console.log(this.state.roomState ? this.state.roomState.hostSocketID : 'No Host');
         return (
             <>
                 <div>
@@ -243,45 +253,6 @@ class DemoPage extends Component {
                 </div>
                 <div>
                     <TextField
-                        placeholder={'Email'}
-                        value={this.state.email}
-                        onChange={event => this.setState({ email: event.target.value })}
-                    />
-                    <TextField
-                        placeholder={'Password'}
-                        value={this.state.password}
-                        onChange={event => this.setState({ password: event.target.value })}
-                    />
-                    <Button
-                        onClick={async () => {
-                            const result = await firebase.auth().signInWithEmailAndPassword(
-                                this.state.email,
-                                this.state.password
-                            ).catch(err => console.log(err));
-                            if (firebase.auth().currentUser) {
-                                const authToken = await firebase.auth().currentUser.getIdToken(true)
-                                    .catch(err => console.log(err));
-                                this.setState({
-                                    authToken,
-                                });
-                                console.log('"Signed in" successfully!');
-                            }
-                        }}
-                    >
-                        Login
-                    </Button>
-                    <Button
-                        onClick={async () => {
-                            const result = await firebase.auth().signOut()
-                                .catch(err => console.log(err));
-                            console.log('Signed out successfully!');
-                        }}
-                    >
-                        Sign Out
-                    </Button>
-                </div>
-                <div>
-                    <TextField
                         placeholder={'Host Room ID'}
                         value={this.state.hostRoomID}
                         onChange={event => this.setState({ hostRoomID: event.target.value })}
@@ -354,32 +325,40 @@ class DemoPage extends Component {
                     </ul>
                 </div>
                 <div>
-                    <Button
-                        onClick={() => {
-                            this.props.emitEvent(
-                                'start_new_round',
-                                {
-                                    roomID: this.state.joinRoomID,
-                                    authToken: this.state.authToken,
-                                }
-                            );
-                        }}
-                    >
-                        Start New Round
-                    </Button>
-                    <Button
-                        onClick={() => {
-                            this.props.emitEvent(
-                                'force_end_bidding',
-                                {
-                                    roomID: this.state.joinRoomID,
-                                    authToken: this.state.authToken,
-                                }
-                            );
-                        }}
-                    >
-                        Force End Bidding
-                    </Button>
+                    {
+                        (this.state.roomState && this.state.roomState.hostSocketID === this.props.roomServiceSocket.id)
+                            ? (
+                                <>
+                                    <Button
+                                        onClick={() => {
+                                            this.props.emitEvent(
+                                                'start_new_round',
+                                                {
+                                                    roomID: this.state.joinRoomID,
+                                                    authToken: this.state.authToken,
+                                                }
+                                            );
+                                        }}
+                                    >
+                                        Start New Round
+                                    </Button>
+                                    <Button
+                                        onClick={() => {
+                                            this.props.emitEvent(
+                                                'force_end_bidding',
+                                                {
+                                                    roomID: this.state.joinRoomID,
+                                                    authToken: this.state.authToken,
+                                                }
+                                            );
+                                        }}
+                                    >
+                                        Force End Bidding
+                                    </Button>
+                                </>
+                            )
+                            : null
+                    }
                 </div>
                 <div>
                     <ul>


### PR DESCRIPTION
Ping me for a demo if needed. Sends a host_closed_room event whenever the host connects to the room and then leaves. Automatically disconnects all users from the room, and then closes the room.

hostSocketID property has been added to the roomState variable that gets passed to the client. Demo page has an example of how to use it to determine if a user is the host. In the image shown, the host options of "Start New Round" and "Force End Bidding" are only shown to the host of the room. This works even if the host is the last person to join their room.

<img width="1357" alt="Screen Shot 2020-11-25 at 12 57 56 PM" src="https://user-images.githubusercontent.com/33878910/100265356-20c15e80-2f1e-11eb-82bf-34c8feff7db9.png">
