### PR TITLE
Fix exception on failed string split

### DIFF
--- a/server/routes/api/v1/authMiddleware.js
+++ b/server/routes/api/v1/authMiddleware.js
@@ -3,8 +3,18 @@ const AuthService = require('../../../services/auth');
 const UNAUTHORIZED_MESSAGE = 'You are not authorized to perform this action';
 
 // Validates the HTTP Authorization Bearer header value
+// NOTE: Validates input constraints, not token
 const validateHeader = (authHeader) => {
-    const parts = authHeader.split(' ');
+    if (!authHeader) {
+        return false;
+    }
+
+    let parts;
+    try {
+        parts = authHeader.split(' ');
+    } catch (e) {
+        return false;
+    }
 
     if (parts.length !== 2) {
         return false;


### PR DESCRIPTION
Fixed an error with the authentication middleware that failed to split `Authorization` header values:

ex:
```
TypeError: Cannot read property 'split' of undefined
0|app      |     at validateHeader (/home/bitnami/Agile-Poker-Bidding/server/routes/api/v1/authMiddleware.js:7:30)
0|app      |     at module.exports (/home/bitnami/Agile-Poker-Bidding/server/routes/api/v1/authMiddleware.js:30:10)
0|app      |     at Layer.handle [as handle_request] (/home/bitnami/Agile-Poker-Bidding/server/node_modules/express/lib/router/layer.js:95:5)
0|app      |     at next (/home/bitnami/Agile-Poker-Bidding/server/node_modules/express/lib/router/route.js:137:13)
0|app      |     at Route.dispatch (/home/bitnami/Agile-Poker-Bidding/server/node_modules/express/lib/router/route.js:112:3)
0|app      |     at Layer.handle [as handle_request] (/home/bitnami/Agile-Poker-Bidding/server/node_modules/express/lib/router/layer.js:95:5)
0|app      |     at /home/bitnami/Agile-Poker-Bidding/server/node_modules/express/lib/router/index.js:281:22
0|app      |     at param (/home/bitnami/Agile-Poker-Bidding/server/node_modules/express/lib/router/index.js:354:14)
0|app      |     at param (/home/bitnami/Agile-Poker-Bidding/server/node_modules/express/lib/router/index.js:365:14)
0|app      |     at Function.process_params (/home/bitnami/Agile-Poker-Bidding/server/node_modules/express/lib/router/index.js:410:3)
```